### PR TITLE
fix mapping Namenszusatz #27

### DIFF
--- a/input/fsh/examples/Patient/UC1-KatrinKinderlieb.fsh
+++ b/input/fsh/examples/Patient/UC1-KatrinKinderlieb.fsh
@@ -8,10 +8,10 @@ Description: "Example for CH EPREG Patient: Mother"
 * extension[pronoun].extension[value].valueCodeableConcept = $loinc#LA29519-8 "she/her/her/hers/herself"
 * identifier[insuranceCardNumber].system = "urn:oid:2.16.756.5.30.1.123.100.1.1.1"
 * identifier[insuranceCardNumber].value = "80756015090002647590"
-* name.text = "Frau Katrin Kinderlieb"
+* name.text = "Katrin Emily Kinderlieb"
 * name.family = "Kinderlieb"
-* name.given = "Katrin"
-* name.prefix = "Frau"
+* name.given[0] = "Katrin"
+* name.given[+] = "Emily"
 * telecom[email].system = #email 
 * telecom[email].value = "katrin.kinderlieb@example.com"
 * telecom[phone][0].system = #phone

--- a/input/fsh/examples/Patient/UC2-FabienneBabyglueck.fsh
+++ b/input/fsh/examples/Patient/UC2-FabienneBabyglueck.fsh
@@ -9,10 +9,10 @@ Description: "Example for CH EPREG Patient: Mother"
 // * identifier[AHVN13]
 * identifier[insuranceCardNumber].system = "urn:oid:2.16.756.5.30.1.123.100.1.1.1"
 * identifier[insuranceCardNumber].value = "80756098765432100000"
-* name.text = "Frau Fabienne Babyglück"
+* name.text = "Fabienne Madeleine Babyglück"
 * name.family = "Babyglück"
-* name.given = "Fabienne"
-* name.prefix = "Frau"
+* name.given[0] = "Fabienne"
+* name.given[+] = "Madeleine"
 * telecom[email].system = #email 
 * telecom[email].value = "fabienne.babyglueck@example.com"
 * telecom[phone][0].system = #phone

--- a/input/fsh/profiles/Patient_Mother.fsh
+++ b/input/fsh/profiles/Patient_Mother.fsh
@@ -76,7 +76,7 @@ Description: "This mapping illustrates the relationship between the CH EPREG pro
 * name.text                                 -> "Vollständiger Name | Nom complet"
 * name.family                               -> "Nachname | Nom de famille"
 * name.given                                -> "Vorname | Prénoms" 
-* name.prefix                               -> "Namenszusatz | Autres prénoms"
+* name.given                                -> "Andere Vornamen (Namenszusatz) | Autres prénoms"
 * telecom[email]                            -> "E-Mailadresse | Courriel"
 * telecom[phone]                            -> "Telefon | N° de téléphone" 
 * telecom[phone]                            -> "use = home: Festnetz | Fixe" 

--- a/input/pagecontent/changelog.md
+++ b/input/pagecontent/changelog.md
@@ -17,6 +17,7 @@ See also open issues on [GitHub](https://github.com/hl7ch/ch-epreg/issues).
 
 #### Fixed 
 * [#14](https://github.com/hl7ch/ch-epreg/issues/14), [#28](https://github.com/hl7ch/ch-epreg/issues/28): Typos
+* [#27](https://github.com/hl7ch/ch-epreg/issues/27): Clarify meaning 'Namenszusatz' and fix mapping
 
 
 ### STU 1 Ballot (2025-05-22)

--- a/input/pagecontent/mapping-concept-dataelements.md
+++ b/input/pagecontent/mapping-concept-dataelements.md
@@ -15,8 +15,8 @@ _Each element that has already been mapped has an entry in the column 'Mapping t
 | 1.2. Name | 1.2. Nom | 0..1 | R |   | 371484003 Patient name (observable entity) | `Patient.name` |   |
 | 1.2.1. Nachname | 1.2.1. Nom de famille | 1..1 | M | String | 184096005 Patient surname (observable entity) | `Patient.name.family` |   |
 | 1.2.2. Vorname | 1.2.2. Prénoms | 1..1 | M | String | 184095009 Patient forename (observable entity) | `Patient.name.given` |   |
-| 1.2.3. Namenszusatz | 1.2.3. Autres prénoms | 0..1 | O | String | 716057004 Patient middle name (observable entity) | `Patient.name.prefix` |   |
-| 1.2.4. Vollständiger Name | 1.2.4. Nom complet | 0..1 | R | String | Vollständiger Name mit Vornamen, Nachnamen und Namenszusatz. Der vollständige Name soll alle Namensteile in ihrer korrekten Reihenfolge abbilden. | `Patient.name.text` |   |
+| 1.2.3. Andere Vornamen (Namenszusatz) | 1.2.3. Autres prénoms | 0..1 | O | String | 716057004 Patient middle name (observable entity) | `Patient.name.given` | 'Namenszusatz' (original name German) is to be understood here as a middle name. |
+| 1.2.4. Vollständiger Name | 1.2.4. Nom complet | 0..1 | R | String | Vollständiger Name mit Vornamen, Nachnamen und anderen Vornamen (Namenszusatz). Der vollständige Name soll alle Namensteile in ihrer korrekten Reihenfolge abbilden. | `Patient.name.text` |   |
 | 1.2.5. Pronomen | 1.2.5. Pronoms | 0..1 | O | String | Für Trans-PatientInnen als optionale Angabe | `Patient.extension:pronoun.extension:value.valueCodeableConcept` |   |
 | 1.3. Geburtsdatum | 1.3. Date de naissance | 0..1 | R | Datum | 184099003 Date of birth (observable entity) | `Patient.birthDate` |   |
 | 1.4. Nationalität | 1.4. Nationalité | 0..\* | O | String |   | `Patient.extension:citizenship.extension:code.valueCodeableConcept` |   |


### PR DESCRIPTION
Updates:
- Clarify meaning and mapping of the element 'Namenszusatz'
- Mapping: [Table](https://build.fhir.org/ig/hl7ch/ch-epreg/branches/27_Namenszusatz/mapping-concept-dataelements.html#:~:text=1.2.3.%20Andere%20Vornamen,a%20middle%20name.), [Profile](https://build.fhir.org/ig/hl7ch/ch-epreg/branches/27_Namenszusatz/StructureDefinition-ch-epreg-patient-mother-mappings.html#:~:text=Andere%20Vornamen%20(-,Namenszusatz,-)%20%7C%20Autres%20pr%C3%A9noms) 
- Examples: [Katrin Kinderlieb](https://build.fhir.org/ig/hl7ch/ch-epreg/branches/27_Namenszusatz/Patient-UC1-KatrinKinderlieb.json.html#:~:text=%22name%22%20%3A%20%5B%0A%20%20%20%20%7B%0A%20%20%20%20%20%20%22text%22%20%3A%20%22Katrin%20Emily%20Kinderlieb%22%2C%0A%20%20%20%20%20%20%22family%22%20%3A%20%22Kinderlieb%22%2C%0A%20%20%20%20%20%20%22given%22%20%3A%20%5B%0A%20%20%20%20%20%20%20%20%22Katrin%22%2C%0A%20%20%20%20%20%20%20%20%22Emily%22%0A%20%20%20%20%20%20%5D%0A%20%20%20%20%7D%0A%20%20%5D%2C), [Fabienne Babyglück](https://build.fhir.org/ig/hl7ch/ch-epreg/branches/27_Namenszusatz/Patient-76c2c5aa-3d7f-438d-b23d-56ce827695fd.json.html#:~:text=%22name%22%20%3A%20%5B%0A%20%20%20%20%7B%0A%20%20%20%20%20%20%22text%22%20%3A%20%22Fabienne%20Madeleine%20Babygl%C3%BCck%22%2C%0A%20%20%20%20%20%20%22family%22%20%3A%20%22Babygl%C3%BCck%22%2C%0A%20%20%20%20%20%20%22given%22%20%3A%20%5B%0A%20%20%20%20%20%20%20%20%22Fabienne%22%2C%0A%20%20%20%20%20%20%20%20%22Madeleine%22%0A%20%20%20%20%20%20%5D%0A%20%20%20%20%7D%0A%20%20%5D%2C)
- [Changelog](https://build.fhir.org/ig/hl7ch/ch-epreg/branches/27_Namenszusatz/changelog.html#:~:text=%2327%3A%20Clarify%20meaning%20%27Namenszusatz%27%20and%20fix%20mapping)

@katie-reynolds: Thank you for your feedback. Do you agree with this update?

@pjolo: Please review the changes.