### PR TITLE
update ignoreWarnings.txt #34

### DIFF
--- a/input/ignoreWarnings.txt
+++ b/input/ignoreWarnings.txt
@@ -5,8 +5,10 @@ None of the codings provided are in the value set 'DocumentEntry.typeCode' (http
 None of the codings provided are in the value set 'IdentifierType' (http://hl7.org/fhir/ValueSet/identifier-type|%
 None of the codings provided are in the value set 'Patient Contact Relationship ' (http://hl7.org/fhir/ValueSet/patient-contactrelationship|%
 
-# Issue coming from the snapshot (base/derived profile)
+# Issue/information coming from the snapshot (base/derived profile)
 The repeating element has a pattern. The pattern will apply to all the repeats (this has not been clear to all users)
+The extension http://hl7.org/fhir/StructureDefinition/elementdefinition-maxValueSet|5.3.0-ballot-tc1 is deprecated with the note: 'Use additionalBinding extension or element instead'
+The extension http://hl7.org/fhir/StructureDefinition/regex|5.3.0-ballot-tc1 is deprecated with the note: 'This was deprecated in favor of using a constraint on the element using FHIRPath, since constraints allow for the provision of a human readable message associated with the regex'
 
 # No valid display values for the given language (information)
 %as no Display Names for the language de-CH 

--- a/input/pagecontent/changelog.md
+++ b/input/pagecontent/changelog.md
@@ -19,6 +19,8 @@ See also open issues on [GitHub](https://github.com/hl7ch/ch-epreg/issues).
 * [#14](https://github.com/hl7ch/ch-epreg/issues/14), [#28](https://github.com/hl7ch/ch-epreg/issues/28): Typos
 * [#27](https://github.com/hl7ch/ch-epreg/issues/27): Clarify meaning 'Namenszusatz' and fix mapping
 
+#### Resolved issues with no impact on the actual IG or its content
+* [#34](https://github.com/hl7ch/ch-epreg/issues/34): Deprecated extensions
 
 ### STU 1 Ballot (2025-05-22)
 Initial published version.


### PR DESCRIPTION
- http://hl7.org/fhir/StructureDefinition/iso21090-SC-coding: fixed with https://github.com/hl7ch/ch-core/pull/397/files
- http://hl7.org/fhir/StructureDefinition/elementdefinition-maxValueSet|5.3.0-ballot-tc1: add to suppressed messages (caused through underlying profile)
- http://hl7.org/fhir/StructureDefinition/regex|5.3.0-ballot-tc1: add to suppressed messages (caused through underlying profile)

@pjolo: please review the changes (see also [qa](https://build.fhir.org/ig/hl7ch/ch-epreg/branches/34_deprecatedExtensions/qa.html))